### PR TITLE
This is an implementation of iterators

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -8,7 +8,8 @@ import (
 func Load(m *memory.Type) {
 	for name, fun := range all {
 		fNode := fun.STRewrite(node.SymTbl{})
-		fVal, _ := fNode.Evaluate(m)
+    // TODO, should we just use value instead of node?
+		fVal, _ := fNode.Evaluate(m, nil, nil)
 		m.SetGlobal(name, fVal)
 	}
 }
@@ -35,3 +36,4 @@ var errorF = node.Function{Parameters: node.List{Elems: []node.Type{v}}, Body: n
 var exitF = node.Function{Parameters: node.List{Elems: []node.Type{v}}, Body: node.Exit{Value: v}}
 
 var v = node.Name("v")
+

--- a/cmd/calc.go
+++ b/cmd/calc.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	// "runtime"
 	"runtime/pprof"
 
 	"os"
@@ -17,8 +18,10 @@ func main() {
 	var eval string
 	var cpuprof string
 	var ast bool
+	var trace string
 	flag.StringVar(&eval, "eval", "", "string to evaluate")
 	flag.StringVar(&cpuprof, "cpuprof", "", "filename for go pprof")
+	flag.StringVar(&trace, "trace", "", "filename for go trace")
 	flag.BoolVar(&ast, "ast", false, "repl outputs AST instead of evaluating")
 
 	flag.Parse()
@@ -66,7 +69,7 @@ func cmdLine(line string) {
 
 	t, err := parser.Parse(line)
 	if len(t) > 0 {
-		fmt.Println(node.Evaluate(m, t[0]))
+		fmt.Println(node.Evaluate(m, t[0], nil, nil))
 	}
 	if err != nil {
 		fmt.Println(err)

--- a/examples/euler_19.calc
+++ b/examples/euler_19.calc
@@ -1,20 +1,23 @@
+fromto = (a, b) -> {
+  while a < b {
+    yield a
+    a = a + 1
+  }
+}
+
 leap = (year) -> ((year % 4 == 0) & (year % 100 != 0)) | (year % 400 == 0)
 
 mdayary = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 
 days = (y, m) -> if m == 1 & leap(y) 29 else mdayary[m] 
 
-y = 1900
 dcount = 0
 sundays = 0
-while y < 2001 {
-  m = 0
-  while m < 12 {
+for y <- fromto(1900, 2001) {
+  for m <- fromto(0, 12) {
     dcount = dcount + days(y, m) 
     if (y != 1900) & (dcount % 7 == 6) sundays = sundays + 1
-    m = m + 1
   }
-  y = y + 1
 }
 
 write(sundays)

--- a/examples/euler_35.calc
+++ b/examples/euler_35.calc
@@ -1,3 +1,26 @@
+fromto = (a, b) -> {
+  while a < b {
+    yield a
+    a = a + 1
+  }
+}
+
+elems = (ary) -> {
+  i = 0
+  while i < #ary {
+    yield ary[i]
+    i = i + 1
+  }
+}
+
+indices = (ary) -> {
+  i = 0
+  while i < #ary {
+    yield i
+    i = i + 1
+  }
+}
+
 binsearch = (a, b, cond) -> {
   if a >= b-1 {
     if cond(b) return b else return error("not found")
@@ -34,9 +57,8 @@ rotations = (n) -> {
   s = toa(n)
   i = 0
   r = []
-  while i < #s {
+  for i <- indices(s) {
     r = r + [aton(s[i: #s] + s[0:i])]
-    i = i + 1
   }
   r
 }
@@ -47,7 +69,7 @@ while i < 1000000 {
   if all(rotations(i), isprime) {
     c = c + 1
   }
-  i = i+1
+  i = i + 1
 }
 write(c)
 

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -14,6 +14,8 @@ package memory
 
 import (
 	"fmt"
+	"slices"
+
 	"github.com/paulsonkoly/calc/types/value"
 )
 
@@ -36,6 +38,17 @@ type Type struct {
 
 // NewType creates a new memory, with an empty global frame and an empty stack
 func NewMemory() *Type { return &Type{global: gframe{}, stack: []Frame{}} }
+
+// Clone creates a copy of memory, that shares global, and has the last 2 frames copied.
+func (m *Type) Clone() *Type {
+	newMem := NewMemory()
+	newMem.global = m.global
+
+	for i := len(m.stack) - 2; 0 <= i && i < len(m.stack); i++ {
+		newMem.stack = append(newMem.stack, slices.Clone(m.stack[i]))
+	}
+	return newMem
+}
 
 // SetGlobal sets a global variable
 func (m *Type) SetGlobal(name string, v value.Type) { m.global[name] = v }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -154,8 +154,10 @@ func assignment(input c.RollbackLexer) ([]c.Node, error) {
 func statement(input c.RollbackLexer) ([]c.Node, error) {
 	return c.Choose(
 		c.Conditional{Gate: c.Assert(acceptToken("if")), OnSuccess: conditional},
-		c.Conditional{Gate: c.Assert(acceptToken("while")), OnSuccess: loop},
+		c.Conditional{Gate: c.Assert(acceptToken("while")), OnSuccess: whileLoop},
+		c.Conditional{Gate: c.Assert(acceptToken("for")), OnSuccess: forLoop},
 		c.Conditional{Gate: c.Assert(acceptToken("return")), OnSuccess: returning},
+		c.Conditional{Gate: c.Assert(acceptToken("yield")), OnSuccess: yield},
 		c.Conditional{Gate: c.Assert(c.And(varName, acceptToken("="))), OnSuccess: assignment},
 		c.Conditional{Gate: c.Ok(), OnSuccess: expression})(input)
 }
@@ -172,12 +174,20 @@ func conditional(input c.RollbackLexer) ([]c.Node, error) {
 		))(input)
 }
 
-func loop(input c.RollbackLexer) ([]c.Node, error) {
+func whileLoop(input c.RollbackLexer) ([]c.Node, error) {
 	return c.Fmap(mkWhile, c.Seq(acceptToken("while"), expression, block))(input)
+}
+
+func forLoop(input c.RollbackLexer) ([]c.Node, error) {
+	return c.Fmap(mkFor, c.Seq(acceptToken("for"), varName, acceptToken("<-"), expression, block))(input)
 }
 
 func returning(input c.RollbackLexer) ([]c.Node, error) {
 	return c.Fmap(mkReturn, c.And(acceptToken("return"), expression))(input)
+}
+
+func yield(input c.RollbackLexer) ([]c.Node, error) {
+	return c.Fmap(mkYield, c.And(acceptToken("yield"), expression))(input)
 }
 
 func function(input c.RollbackLexer) ([]c.Node, error) {

--- a/parser/transformer.go
+++ b/parser/transformer.go
@@ -30,6 +30,15 @@ func mkReturn(nodes []c.Node) []c.Node {
 	return []c.Node{n}
 }
 
+// mkYield is for yield statements
+func mkYield(nodes []c.Node) []c.Node {
+	if len(nodes)!= 2 {
+		log.Panicf("incorrect number of sub nodes for yield (%d)", len(nodes))
+	}
+	n := node.Yield{Target: nodes[1].(node.Type)}
+	return []c.Node{n}
+}
+
 // mkLeftChain rewrites a sequence of binary operators applied on operands in a
 // left assictive structure
 //
@@ -138,4 +147,13 @@ func mkWhile(nodes []c.Node) []c.Node {
 	}
 	n := node.While{Condition: nodes[1].(node.Type), Body: nodes[2].(node.Type)}
 	return []c.Node{n}
+}
+
+// mkFor creates a for loop structure
+func mkFor(nodes []c.Node) []c.Node {
+    if len(nodes) !=5 {
+        log.Panicf("incorrect number of sub nodes for for (%d)", len(nodes))
+    }
+    n := node.For{VarRef: nodes[1].(node.Type), Iterator: nodes[3].(node.Type), Body: nodes[4].(node.Type)}
+    return []c.Node{n}
 }

--- a/types/node/evaluator.go
+++ b/types/node/evaluator.go
@@ -12,33 +12,41 @@ import (
 )
 
 type Evaluator interface {
-	Evaluate(m *memory.Type) (value.Type, bool)
+	Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool)
 }
 
 // Evaluate evaluates the given AST node producing a Value
-func Evaluate(m *memory.Type, e Evaluator) value.Type {
-	r, _ := e.Evaluate(m)
+func Evaluate(m *memory.Type, e Evaluator, yield chan<- value.Type, control <-chan bool) value.Type {
+	r, _ := e.Evaluate(m, yield, control)
 	return r
 }
 
-func (i Int) Evaluate(_ *memory.Type) (value.Type, bool)    { return value.NewInt(int(i)), false }
-func (f Float) Evaluate(_ *memory.Type) (value.Type, bool)  { return value.NewFloat(float64(f)), false }
-func (b Bool) Evaluate(_ *memory.Type) (value.Type, bool)   { return value.NewBool(bool(b)), false }
-func (s String) Evaluate(_ *memory.Type) (value.Type, bool) { return value.NewString(string(s)), false }
+func (i Int) Evaluate(_ *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	return value.NewInt(int(i)), false
+}
+func (f Float) Evaluate(_ *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	return value.NewFloat(float64(f)), false
+}
+func (b Bool) Evaluate(_ *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	return value.NewBool(bool(b)), false
+}
+func (s String) Evaluate(_ *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	return value.NewString(string(s)), false
+}
 
-func (a List) Evaluate(m *memory.Type) (value.Type, bool) {
+func (a List) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
 	elems := a.Elems
 	evalElems := make([]value.Type, len(elems))
 
 	for i, e := range elems {
-		evalElems[i] = Evaluate(m, e)
+		evalElems[i] = Evaluate(m, e, yield, control)
 	}
 
 	return value.NewArray(evalElems), false
 }
 
-func (c Call) Evaluate(m *memory.Type) (value.Type, bool) {
-	f := Evaluate(m, c.Name)
+func (c Call) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	f := Evaluate(m, c.Name, yield, control)
 
 	fVal, ok := f.ToFunction()
 	if !ok {
@@ -58,13 +66,13 @@ func (c Call) Evaluate(m *memory.Type) (value.Type, bool) {
 	// ie the closure frame might contain variables that affect the argument evaluation
 	frm := memory.NewFrame(fNode.LocalCnt)
 	for i, a := range args {
-		frm.Set(i, Evaluate(m, a))
+		frm.Set(i, Evaluate(m, a, yield, control))
 	}
 	if fVal.Frame != nil {
 		m.PushFrame(fVal.Frame.(memory.Frame))
 	}
 	m.PushFrame(frm)
-	r := Evaluate(m, fNode.Body)
+	r := Evaluate(m, fNode.Body, yield, control)
 	if fVal.Frame != nil {
 		m.PopFrame()
 	}
@@ -72,20 +80,20 @@ func (c Call) Evaluate(m *memory.Type) (value.Type, bool) {
 	return r, false
 }
 
-func (u UnOp) Evaluate(m *memory.Type) (value.Type, bool) {
+func (u UnOp) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
 	switch u.Op {
 
 	case "-":
-		r := Evaluate(m, u.Target)
+		r := Evaluate(m, u.Target, yield, control)
 		r = r.Arith("*", value.NewInt(-1))
 		return r, false
 
 	case "#":
-		r := Evaluate(m, u.Target)
+		r := Evaluate(m, u.Target, yield, control)
 		return r.Len(), false
 
-  case "!":
-		r := Evaluate(m, u.Target)
+	case "!":
+		r := Evaluate(m, u.Target, yield, control)
 		r = r.Not()
 		return r, false
 
@@ -95,23 +103,23 @@ func (u UnOp) Evaluate(m *memory.Type) (value.Type, bool) {
 	panic("unreachable code")
 }
 
-func (b BinOp) Evaluate(m *memory.Type) (value.Type, bool) {
+func (b BinOp) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
 	switch b.Op {
 
 	case "+", "-", "*", "/":
-		return Evaluate(m, b.Left).Arith(b.Op, Evaluate(m, b.Right)), false
+		return Evaluate(m, b.Left, yield, control).Arith(b.Op, Evaluate(m, b.Right, yield, control)), false
 
-  case "%":
-		return Evaluate(m, b.Left).Mod(Evaluate(m, b.Right)), false
+	case "%":
+		return Evaluate(m, b.Left, yield, control).Mod(Evaluate(m, b.Right, yield, control)), false
 
 	case "&", "|":
-		return Evaluate(m, b.Left).Logic(b.Op, Evaluate(m, b.Right)), false
+		return Evaluate(m, b.Left, yield, control).Logic(b.Op, Evaluate(m, b.Right, yield, control)), false
 
 	case "==", "!=":
-		return Evaluate(m, b.Left).Eq(b.Op, Evaluate(m, b.Right)), false
+		return Evaluate(m, b.Left, yield, control).Eq(b.Op, Evaluate(m, b.Right, yield, control)), false
 
 	case "<", "<=", ">", ">=":
-		return Evaluate(m, b.Left).Relational(b.Op, Evaluate(m, b.Right)), false
+		return Evaluate(m, b.Left, yield, control).Relational(b.Op, Evaluate(m, b.Right, yield, control)), false
 
 	default:
 		log.Panicf("unexpected single character in evaluator: %s", b.Op)
@@ -119,8 +127,8 @@ func (b BinOp) Evaluate(m *memory.Type) (value.Type, bool) {
 	panic("unreachable code")
 }
 
-func (a Assign) Evaluate(m *memory.Type) (value.Type, bool) {
-	v := Evaluate(m, a.Value)
+func (a Assign) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	v := Evaluate(m, a.Value, yield, control)
 
 	switch vr := a.VarRef.(type) {
 	case Local:
@@ -133,40 +141,40 @@ func (a Assign) Evaluate(m *memory.Type) (value.Type, bool) {
 	return v, false
 }
 
-func (i IndexAt) Evaluate(m *memory.Type) (value.Type, bool) {
-	ary := Evaluate(m, i.Ary)
-	at := Evaluate(m, i.At)
+func (i IndexAt) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	ary := Evaluate(m, i.Ary, yield, control)
+	at := Evaluate(m, i.At, yield, control)
 	return ary.Index(at), false
 }
 
-func (i IndexFromTo) Evaluate(m *memory.Type) (value.Type, bool) {
-	ary := Evaluate(m, i.Ary)
-	from := Evaluate(m, i.From)
-	to := Evaluate(m, i.To)
+func (i IndexFromTo) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	ary := Evaluate(m, i.Ary, yield, control)
+	from := Evaluate(m, i.From, yield, control)
+	to := Evaluate(m, i.To, yield, control)
 	return ary.Index(from, to), false
 }
 
-func (f Function) Evaluate(m *memory.Type) (value.Type, bool) {
+func (f Function) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
 	return value.NewFunction(&f, m.Top()), false
 }
 
-func (n Name) Evaluate(m *memory.Type) (value.Type, bool) {
+func (n Name) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
 	return m.LookUpGlobal(string(n)), false
 }
 
-func (l Local) Evaluate(m *memory.Type) (value.Type, bool) {
+func (l Local) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
 	return m.LookUpLocal(int(l)), false
 }
 
-func (c Closure) Evaluate(m *memory.Type) (value.Type, bool) {
+func (c Closure) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
 	return m.LookUpClosure(int(c)), false
 }
 
-func (i If) Evaluate(m *memory.Type) (value.Type, bool) {
-	c := Evaluate(m, i.Condition)
+func (i If) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	c := Evaluate(m, i.Condition, yield, control)
 	if cc, ok := c.ToBool(); ok {
 		if cc {
-			return i.TrueCase.Evaluate(m)
+			return i.TrueCase.Evaluate(m, yield, control)
 		} else {
 			return value.NoResultError, false
 		}
@@ -175,43 +183,101 @@ func (i If) Evaluate(m *memory.Type) (value.Type, bool) {
 	}
 }
 
-func (i IfElse) Evaluate(m *memory.Type) (value.Type, bool) {
-	c := Evaluate(m, i.Condition)
+func (i IfElse) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	c := Evaluate(m, i.Condition, yield, control)
 	if cc, ok := c.ToBool(); ok {
 		if cc {
-			return i.TrueCase.Evaluate(m)
+			return i.TrueCase.Evaluate(m, yield, control)
 		} else {
-			return i.FalseCase.Evaluate(m)
+			return i.FalseCase.Evaluate(m, yield, control)
 		}
 	} else {
 		return value.TypeError, false
 	}
 }
 
-func (w While) Evaluate(m *memory.Type) (value.Type, bool) {
+func (w While) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
 	r := value.Type(value.NoResultError)
 	returning := false
 	for {
 		if returning {
 			return r, returning
 		}
-		cond := Evaluate(m, w.Condition)
+		cond := Evaluate(m, w.Condition, yield, control)
 		if ccond, ok := cond.ToBool(); ok {
 			if !bool(ccond) {
 				return r, returning
 			}
-			r, returning = w.Body.Evaluate(m)
+			r, returning = w.Body.Evaluate(m, yield, control)
 		} else {
 			return value.TypeError, false
 		}
 	}
 }
 
-func (r Return) Evaluate(m *memory.Type) (value.Type, bool) {
-	return Evaluate(m, r.Target), true
+func (f For) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	myYield := make(chan value.Type)
+	myControl := make(chan bool)
+
+	// start a go routine as a co-routine to kick off the iterator
+	go func() {
+    // the iterator can't modify our stack, if it was pushing frames, our view
+    // of the stack would be corrupted
+    myM := m.Clone()
+		Evaluate(myM, f.Iterator, myYield, myControl)
+		close(myYield)
+	}()
+
+	r := value.NoResultError
+	returning := false
+	for {
+		v, ok := <-myYield
+
+		if !ok {
+      close(myControl)
+			return r, returning
+		}
+
+		switch vr := f.VarRef.(type) {
+		case Local:
+			m.Set(int(vr), v)
+    case Name:
+      m.SetGlobal(string(vr), v)
+    default:
+      panic("assignment lhs is neither local or global variable")
+		}
+
+    r, returning = f.Body.Evaluate(m, yield, control)
+
+    // we need to stop and wait for the iterator
+    // myControl <- !returning
+	}
 }
 
-func (r Read) Evaluate(m *memory.Type) (value.Type, bool) {
+func (y Yield) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	v := Evaluate(m, y.Target, yield, control)
+	yield <- v
+	// c := <-control
+  c := true
+	return value.NoResultError, !c
+}
+
+func (r Return) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	return Evaluate(m, r.Target, yield, control), true
+}
+
+func (b Block) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	if len(b.Body) < 1 {
+		panic("empty block")
+	}
+	r, returning := b.Body[0].Evaluate(m, yield, control)
+	for i := 1; i < len(b.Body) && !returning; i++ {
+		r, returning = b.Body[i].Evaluate(m, yield, control)
+	}
+	return r, returning
+}
+
+func (r Read) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
 	b := bufio.NewReader(os.Stdin)
 	line, err := b.ReadString('\n')
 	if err != nil {
@@ -221,14 +287,14 @@ func (r Read) Evaluate(m *memory.Type) (value.Type, bool) {
 	return value.NewString(line), false
 }
 
-func (w Write) Evaluate(m *memory.Type) (value.Type, bool) {
-	v := Evaluate(m, w.Value)
+func (w Write) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	v := Evaluate(m, w.Value, yield, control)
 	fmt.Println(v)
 	return value.NoResultError, false
 }
 
-func (a Aton) Evaluate(m *memory.Type) (value.Type, bool) {
-	sv, ok := Evaluate(m, a.Value).ToString()
+func (a Aton) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	sv, ok := Evaluate(m, a.Value, yield, control).ToString()
 	if !ok {
 		return value.TypeError, false
 	}
@@ -244,34 +310,23 @@ func (a Aton) Evaluate(m *memory.Type) (value.Type, bool) {
 	return value.ConversionError, false
 }
 
-func (t Toa) Evaluate(m *memory.Type) (value.Type, bool) {
-	v := Evaluate(m, t.Value)
+func (t Toa) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	v := Evaluate(m, t.Value, yield, control)
 	return value.NewString(fmt.Sprint(v)), false
 }
 
-func (e Error) Evaluate(m *memory.Type) (value.Type, bool) {
-	v := Evaluate(m, e.Value)
+func (e Error) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	v := Evaluate(m, e.Value, yield, control)
 	if msg, ok := v.ToString(); ok {
 		return value.NewError(&msg), false
 	}
 	return value.TypeError, false
 }
 
-func (e Exit) Evaluate(m *memory.Type) (value.Type, bool) {
-	v := Evaluate(m, e.Value)
+func (e Exit) Evaluate(m *memory.Type, yield chan<- value.Type, control <-chan bool) (value.Type, bool) {
+	v := Evaluate(m, e.Value, yield, control)
 	if i, ok := v.ToInt(); ok {
 		os.Exit(i)
 	}
 	return value.TypeError, false
-}
-
-func (b Block) Evaluate(m *memory.Type) (value.Type, bool) {
-	if len(b.Body) < 1 {
-		panic("empty block")
-	}
-	r, returning := b.Body[0].Evaluate(m)
-	for i := 1; i < len(b.Body) && !returning; i++ {
-		r, returning = b.Body[i].Evaluate(m)
-	}
-	return r, returning
 }

--- a/types/node/graphvizzer.go
+++ b/types/node/graphvizzer.go
@@ -60,7 +60,9 @@ func (u IndexFromTo) Option() opt { return opteratorOpts }
 func (i If) Option() opt          { return defaultOpts }
 func (i IfElse) Option() opt      { return defaultOpts }
 func (w While) Option() opt       { return defaultOpts }
+func (f For) Option() opt         { return defaultOpts }
 func (r Return) Option() opt      { return defaultOpts }
+func (y Yield) Option() opt       { return defaultOpts }
 func (r Read) Option() opt        { return defaultOpts }
 func (w Write) Option() opt       { return defaultOpts }
 func (a Aton) Option() opt        { return defaultOpts }
@@ -88,7 +90,9 @@ func (u IndexFromTo) Label() string { return "@" }
 func (i If) Label() string          { return fmt.Sprintf("%T", i) }
 func (i IfElse) Label() string      { return fmt.Sprintf("%T", i) }
 func (w While) Label() string       { return fmt.Sprintf("%T", w) }
+func (f For) Label() string         { return fmt.Sprintf("%T", f) }
 func (r Return) Label() string      { return fmt.Sprintf("%T", r) }
+func (y Yield) Label() string       { return fmt.Sprintf("%T", y) }
 func (r Read) Label() string        { return fmt.Sprintf("%T", r) }
 func (w Write) Label() string       { return fmt.Sprintf("%T", w) }
 func (a Aton) Label() string        { return fmt.Sprintf("%T", a) }

--- a/types/node/node.go
+++ b/types/node/node.go
@@ -79,9 +79,21 @@ type While struct {
 	Body      Type // Body is the loop body
 }
 
+// For is a loop for iterators ans generators
+type For struct {
+	VarRef   Type // VarRef is variable reference
+	Iterator Type // Value is assigned value
+	Body     Type // Body is the loop body
+}
+
 // Return is a return statement
 type Return struct {
 	Target Type // Target is the returned value
+}
+
+// Yield statement
+type Yield struct {
+	Target Type // Target is the yielded value
 }
 
 // Variable name

--- a/types/node/repl.go
+++ b/types/node/repl.go
@@ -94,11 +94,11 @@ func Loop(r lineReader, p Parser, m *memory.Type, doOut bool, ast bool) {
 			} else {
 				t[0] = t[0].STRewrite(SymTbl{})
 				// t[0].PrettyPrint(0)
-				v := Evaluate(m, t[0])
+				v := Evaluate(m, t[0], nil, nil)
 
 				for _, e := range t[1:] {
 					e := e.STRewrite(SymTbl{})
-					v = Evaluate(m, e)
+					v = Evaluate(m, e, nil, nil)
 				}
 
 				if doOut {

--- a/types/node/strewriter.go
+++ b/types/node/strewriter.go
@@ -73,8 +73,32 @@ func (w While) STRewrite(symTbl SymTbl) Type {
 	return While{Condition: w.Condition.STRewrite(symTbl), Body: w.Body.STRewrite(symTbl)}
 }
 
+func (f For) STRewrite(symTbl SymTbl) Type {
+  iterator := f.Iterator.STRewrite(symTbl)
+  
+	varRef := f.VarRef.(Name)
+	name := string(varRef)
+
+	if len(symTbl) < 1 {
+	return For{VarRef: varRef, Iterator: iterator, Body: f.Body.STRewrite(symTbl)}
+	}
+
+	ix, ok := symTbl[len(symTbl)-1][name]
+	if !ok {
+		l := len(symTbl[len(symTbl)-1])
+		symTbl[len(symTbl)-1][name] = l
+		ix = l
+	}
+
+	return For{VarRef: Local(ix), Iterator: iterator, Body: f.Body.STRewrite(symTbl)}
+}
+
 func (r Return) STRewrite(symTbl SymTbl) Type {
 	return Return{Target: r.Target.STRewrite(symTbl)}
+}
+
+func (y Yield) STRewrite(symTbl SymTbl) Type {
+	return Yield{Target: y.Target.STRewrite(symTbl)}
 }
 
 func (n Name) STRewrite(symTbl SymTbl) Type {


### PR DESCRIPTION
This is currently not performant enough, because it simulates coroutines with 2 go routines that switch lock-stepped with two channels. The switching overhead is too much for this to be feasible for iterators.

Probably we would need a bytecode interpreter first, in which we can have fine grain control over context switches. This needs to be close to a simple jump with minimal overhead for switching between stacks.