### PR TITLE
Fix indexing

### DIFF
--- a/cmd/calc/calc_test.go
+++ b/cmd/calc/calc_test.go
@@ -43,6 +43,7 @@ var testData = [...]TestDatum{
 	{"string indexing/complex empty", "\"apple\" [ 1 : 1]", nil, value.NewString(""), nil},
 	{"indices/all from stack", "\"apple\"[ 1+0 : 3+0 ]", nil, value.NewString("pp"), nil},
 	{"indexing/multidimensional", "[[1,2], 3, 4][0][1]", nil, value.NewInt(2), nil},
+	{"indexing/from stack", "[1, 2, 3][4-2]", nil, value.NewInt(3), nil},
 
 	{"string concatenation", "\"abc\" + \"def\"", nil, value.NewString("abcdef"), nil},
 

--- a/cmd/calc/calc_test.go
+++ b/cmd/calc/calc_test.go
@@ -37,6 +37,7 @@ var testData = [...]TestDatum{
 	{"array lit with leading newline", "[\n1,2,\n3,4]", nil, value.NewArray([]value.Type{value.NewInt(1), value.NewInt(2), value.NewInt(3), value.NewInt(4)}), nil},
 
 	{"simple arithmetic/addition", "1+2", nil, value.NewInt(3), nil},
+	{"bitwise logic", "~(1<<1) & 7", nil, value.NewInt(5), nil},
 
 	{"string indexing/simple", "\"apple\"[1]", nil, value.NewString("p"), nil},
 	{"string indexing/complex empty", "\"apple\" [ 1 : 1]", nil, value.NewString(""), nil},

--- a/parser/token_wrapper.go
+++ b/parser/token_wrapper.go
@@ -17,7 +17,7 @@ import (
 
 type tokenWrapper struct{}
 
-var ops = [...]string{"+", "-", "*", "/", "<", ">", "<=", ">=", "==", "!=", "&&", "||", "&", "|", "%", "#", "~", ":", "!"}
+var ops = [...]string{"+", "-", "*", "/", "<", ">", "<=", ">=", "==", "!=", "&&", "||", "&", "|", "<<", ">>", "%", "#", "~", ":", "!"}
 
 func (tokenWrapper) Wrap(t combinator.Token) combinator.Node {
 	realT := t.(token.Type)

--- a/parser/transformer.go
+++ b/parser/transformer.go
@@ -81,13 +81,11 @@ func mkIndex(nodes []c.Node) []c.Node {
 	r := nodes[0]
 
 	for _, n := range nodes[1:] {
-		switch n := n.(type) {
-		case node.BinOp:
+		if n, ok := n.(node.BinOp); ok && n.Op == ":" {
 			r = node.IndexFromTo{Ary: r.(node.Type), From: n.Left, To: n.Right}
-		default:
-			r = node.IndexAt{Ary: r.(node.Type), At: n.(node.Type)}
-
+			continue
 		}
+		r = node.IndexAt{Ary: r.(node.Type), At: n.(node.Type)}
 	}
 
 	return []c.Node{r}


### PR DESCRIPTION
2 bugs were found in #15 . We need to put examples in regression suite....

Bug no.1: << and >> were missing from operator list panicing the parser on these operators.
Bug no.2: indexing with a binop not ':' caused us taking the IX2 path vs IX1.