### PR TITLE
Fix regression introduced with temp optimisation

### DIFF
--- a/cmd/calc/calc_test.go
+++ b/cmd/calc/calc_test.go
@@ -204,6 +204,8 @@ var testData = [...]TestDatum{
   }`, nil, value.Nil, nil,
 	},
 
+	{"regression/tmp optimisation", `aton("1" + "2") + 3`, nil, value.NewInt(15), nil},
+
 	{"qsort",
 		`{
 	       filter = (pred, ary) -> {

--- a/types/node/bytecoder.go
+++ b/types/node/bytecoder.go
@@ -149,9 +149,11 @@ func (f Function) byteCode(srcsel int, bcd bcData, cr compResult) bytecode.Type 
 }
 
 func (c Call) byteCode(srcsel int, bcd bcData, cr compResult) bytecode.Type {
+	nbcd := bcData{inFor: bcd.inFor, forbidTemp: bcd.forbidTemp, opDepth: 0}
+
 	// push the arguments
 	for _, arg := range c.Arguments.Elems {
-		instr := arg.byteCode(0, bcd, cr)
+		instr := arg.byteCode(0, nbcd, cr)
 		if instr.Src0() != bytecode.AddrStck {
 			instr |= bytecode.New(bytecode.PUSH)
 			*cr.CS = append(*cr.CS, instr)


### PR DESCRIPTION
When a function call was part of an arithmetic expression the operator depth wasn't re-set by the function call causing the temp value to escape up to the function bytecode.