### PR TITLE
Fix when a function is defined in a for loop. 

### DIFF
--- a/cmd/calc/calc_test.go
+++ b/cmd/calc/calc_test.go
@@ -205,6 +205,15 @@ var testData = [...]TestDatum{
 	},
 
 	{"regression/tmp optimisation", `aton("1" + "2") + 3`, nil, value.NewInt(15), nil},
+	{"regression/function in for",
+		`{
+       f = () -> for i <- fromto(1,2) {
+         yield () -> return 13
+       }
+
+       for i <- f() i()
+     }`, nil, value.NewInt(13), nil,
+	},
 
 	{"qsort",
 		`{

--- a/types/node/bytecoder.go
+++ b/types/node/bytecoder.go
@@ -127,12 +127,14 @@ func (n Name) byteCode(srcsel int, _ bcData, cr compResult) bytecode.Type {
 	return bytecode.EncodeSrc(srcsel, bytecode.AddrGbl, ix)
 }
 
-func (f Function) byteCode(srcsel int, bcd bcData, cr compResult) bytecode.Type {
+func (f Function) byteCode(srcsel int, _ bcData, cr compResult) bytecode.Type {
 	instr := bytecode.New(bytecode.JMP)
 	*cr.CS = append(*cr.CS, instr)
 	jmpAddr := len(*cr.CS) - 1
 
-	instr = f.Body.byteCode(0, bcd, cr)
+	nbcd := bcData{inFor: false, forbidTemp: false, opDepth: 0}
+
+	instr = f.Body.byteCode(0, nbcd, cr)
 	instr |= bytecode.New(bytecode.RET)
 	*cr.CS = append(*cr.CS, instr)
 


### PR DESCRIPTION
Caused interpreter to panic.

Because we didnt stop the inFor to propagate into function body we compiled an extra RCONT in the function.