### PR TITLE
some changes in how we clone contexts

### DIFF
--- a/memory/memory.go
+++ b/memory/memory.go
@@ -25,7 +25,6 @@ package memory
 
 import (
 	"fmt"
-	"slices"
 
 	"github.com/paulsonkoly/calc/types/dbginfo"
 	"github.com/paulsonkoly/calc/types/value"
@@ -61,13 +60,14 @@ func New() *Type {
 // of the stack will be deep copied.
 func (m *Type) Clone() *Type {
 	if len(m.fp) < 2 {
-		frm := slices.Clone(m.stack)
-		return &Type{sp: m.sp, fp: []int{}, global: m.global, closure: m.closure, stack: frm}
+		return &Type{sp: m.sp, fp: []int{}, global: m.global, closure: m.closure, stack: []value.Type{}}
 	}
 	fp := m.fp[len(m.fp)+localFP]
 	le := m.fp[len(m.fp)+localFE]
-	frm := slices.Clone(m.stack[fp:m.sp])
-	return &Type{sp: len(frm), fp: []int{0, le - fp}, global: m.global, closure: m.closure, stack: frm}
+	newStackSize := max(m.sp-fp, minStackSize)
+	newStack := make([]value.Type, newStackSize)
+	copy(newStack, m.stack[fp:m.sp])
+	return &Type{sp: m.sp - fp, fp: []int{0, le - fp}, global: m.global, closure: m.closure, stack: newStack}
 }
 
 // SetGlobal sets a global variable.

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -30,14 +30,13 @@ type context struct {
 }
 
 type Type struct {
-	freeList *list.List      // freed memory objects
-	ctx      *context        // ctx is the context tree
-	CR       compresult.Type // cr is the compilation result
+	ctx *context        // ctx is the context tree
+	CR  compresult.Type // cr is the compilation result
 }
 
 // New creates a new virtual machine using memory from m and code and data from cr.
 func New(m *memory.Type, cr compresult.Type) *Type {
-	return &Type{freeList: list.New(), ctx: &context{m: m, children: []*context{}}, CR: cr}
+	return &Type{ctx: &context{m: m, children: []*context{}}, CR: cr}
 }
 
 // Run executes the run loop.
@@ -50,6 +49,8 @@ func (vm *Type) Run(retResult bool) (value.Type, error) {
 	cs := vm.CR.CS
 	tmp := value.Nil
 	var err error
+
+	freeList := list.New()
 
 	for ip < len(*cs) {
 		instr := (*cs)[ip]
@@ -408,9 +409,9 @@ func (vm *Type) Run(retResult bool) (value.Type, error) {
 			ctxp.ip = ip + jmp - 1
 
 			var free *memory.Type
-			front := vm.freeList.Front()
+			front := freeList.Front()
 			if front != nil {
-				vm.freeList.Remove(front)
+				freeList.Remove(front)
 				free = front.Value.(*context).m
 			}
 			m = m.Clone(free)
@@ -420,14 +421,14 @@ func (vm *Type) Run(retResult bool) (value.Type, error) {
 
 		case bytecode.RCONT:
 			last := ctxp.children[len(ctxp.children)-1]
-			vm.freeList.PushFront(last)
+			freeList.PushFront(last)
 			ctxp.children = ctxp.children[:len(ctxp.children)-1]
 
 		case bytecode.DCONT:
 			ctxp = ctxp.parent
 			if len(ctxp.children) > 0 {
 				last := ctxp.children[len(ctxp.children)-1]
-				vm.freeList.PushFront(last)
+				freeList.PushFront(last)
 				ctxp.children = ctxp.children[:len(ctxp.children)-1]
 			}
 			m = ctxp.m


### PR DESCRIPTION
Idea here is to re-use contexts that are freed up. Instead of throwing them away they can go on a freelist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced the stack cloning process to ensure accurate size calculation and element copying, improving memory operation reliability.
- **New Features**
	- Implemented a `freeList` managed by a linked list for efficient memory context recycling in the `Run` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->