### PR TITLE
Fix accidental removal of cleanup

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -606,6 +606,8 @@ func (vm *Type) dumpStack(ctx *context, ip int, err error, values ...value.Type)
 		m.DumpStack(vm.CR.Dbg)
 	}
 	// reset state for the next run
+	vm.main.m.Reset()
+	vm.main.ip = len(*vm.CR.CS)
 	vm.main.children.Clear()
 
 	return value.Nil, err


### PR DESCRIPTION
Caused interpreter panic.
Regression introed in #25. Repro code:

```scheme
for i <- g() 1
for i <- g() 1
```