### PR TITLE
while loop optimisation

### DIFF
--- a/types/bytecode/bytecode.go
+++ b/types/bytecode/bytecode.go
@@ -89,7 +89,8 @@ const (
 	ARR // ARR pushes the src0 + [src1]
 
 	JMP  // JMP jumps relative to ip + src0
-	JMPF // JMPF jumps relative to ip+src1 if src0 is false or ip+src2 if src0 is not bool
+	JMPF // JMPF jumps relative to ip+src1 if src0 is false 
+  JMPT // JMPT jumps relative to ip+src1 if src0 is true
 	FUNC // FUNC pushes a function value sourced from src0 while setting the closure frame in it to current top
 	CALL // CALL calls src0 with argument cnt src1
 	RET  // RET returns from a function call pushing src0 after rolling back the stack

--- a/types/bytecode/bytecode.go
+++ b/types/bytecode/bytecode.go
@@ -89,8 +89,8 @@ const (
 	ARR // ARR pushes the src0 + [src1]
 
 	JMP  // JMP jumps relative to ip + src0
-	JMPF // JMPF jumps relative to ip+src1 if src0 is false 
-  JMPT // JMPT jumps relative to ip+src1 if src0 is true
+	JMPF // JMPF jumps relative to ip+src1 if src0 is false
+	JMPT // JMPT jumps relative to ip+src1 if src0 is true
 	FUNC // FUNC pushes a function value sourced from src0 while setting the closure frame in it to current top
 	CALL // CALL calls src0 with argument cnt src1
 	RET  // RET returns from a function call pushing src0 after rolling back the stack

--- a/types/bytecode/opcode_string.go
+++ b/types/bytecode/opcode_string.go
@@ -36,19 +36,20 @@ func _() {
 	_ = x[ARR-25]
 	_ = x[JMP-26]
 	_ = x[JMPF-27]
-	_ = x[FUNC-28]
-	_ = x[CALL-29]
-	_ = x[RET-30]
-	_ = x[CCONT-31]
-	_ = x[DCONT-32]
-	_ = x[RCONT-33]
-	_ = x[SCONT-34]
-	_ = x[YIELD-35]
-	_ = x[READ-36]
-	_ = x[WRITE-37]
-	_ = x[ATON-38]
-	_ = x[TOA-39]
-	_ = x[EXIT-40]
+	_ = x[JMPT-28]
+	_ = x[FUNC-29]
+	_ = x[CALL-30]
+	_ = x[RET-31]
+	_ = x[CCONT-32]
+	_ = x[DCONT-33]
+	_ = x[RCONT-34]
+	_ = x[SCONT-35]
+	_ = x[YIELD-36]
+	_ = x[READ-37]
+	_ = x[WRITE-38]
+	_ = x[ATON-39]
+	_ = x[TOA-40]
+	_ = x[EXIT-41]
 	_ = x[PUSHTMP-65]
 	_ = x[ADDTMP-68]
 	_ = x[SUBTMP-69]
@@ -71,7 +72,7 @@ func _() {
 }
 
 const (
-	_OpCode_name_0 = "NOPPUSHPOPMOVADDSUBMULDIVMODINCNOTANDORLTGTLEGEEQNELSHRSHFLIPIX1IX2LENARRJMPJMPFFUNCCALLRETCCONTDCONTRCONTSCONTYIELDREADWRITEATONTOAEXIT"
+	_OpCode_name_0 = "NOPPUSHPOPMOVADDSUBMULDIVMODINCNOTANDORLTGTLEGEEQNELSHRSHFLIPIX1IX2LENARRJMPJMPFJMPTFUNCCALLRETCCONTDCONTRCONTSCONTYIELDREADWRITEATONTOAEXIT"
 	_OpCode_name_1 = "PUSHTMP"
 	_OpCode_name_2 = "ADDTMPSUBTMPMULTMPDIVTMPMODTMP"
 	_OpCode_name_3 = "NOTTMPANDTMPORTMPLTTMPGTTMPLETMPGETMPEQTMPNETMPLSHTMPRSHTMPFLIPTMP"
@@ -79,14 +80,14 @@ const (
 )
 
 var (
-	_OpCode_index_0 = [...]uint8{0, 3, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34, 37, 39, 41, 43, 45, 47, 49, 51, 54, 57, 61, 64, 67, 70, 73, 76, 80, 84, 88, 91, 96, 101, 106, 111, 116, 120, 125, 129, 132, 136}
+	_OpCode_index_0 = [...]uint8{0, 3, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34, 37, 39, 41, 43, 45, 47, 49, 51, 54, 57, 61, 64, 67, 70, 73, 76, 80, 84, 88, 92, 95, 100, 105, 110, 115, 120, 124, 129, 133, 136, 140}
 	_OpCode_index_2 = [...]uint8{0, 6, 12, 18, 24, 30}
 	_OpCode_index_3 = [...]uint8{0, 6, 12, 17, 22, 27, 32, 37, 42, 47, 53, 59, 66}
 )
 
 func (i OpCode) String() string {
 	switch {
-	case i <= 40:
+	case i <= 41:
 		return _OpCode_name_0[_OpCode_index_0[i]:_OpCode_index_0[i+1]]
 	case i == 65:
 		return _OpCode_name_1

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -284,7 +284,7 @@ func (vm *Type) Run(retResult bool) (value.Type, error) {
 
 			ip += src0Imm - 1
 
-		case bytecode.JMPF:
+		case bytecode.JMPF, bytecode.JMPT:
 			src0 := vm.fetch(instr.Src0(), instr.Src0Addr(), m, ds)
 			src1Imm := instr.Src1Addr()
 
@@ -293,7 +293,7 @@ func (vm *Type) Run(retResult bool) (value.Type, error) {
 			if !ok {
 				return vm.dumpStack(ctxp, ip, value.ErrType, src0)
 			}
-			if !b {
+			if (opCode == bytecode.JMPF && !b) || (opCode == bytecode.JMPT && b) {
 				ip += src1Imm - 1
 			}
 


### PR DESCRIPTION
When a while loop isn't discarding, we eliminated a pair of push/pop from the loop body assuming the loop body didn't put its result on the stack. This is by turning the loop into a post check loop where the post check jump doesn't jump on the initial pop but jumps directly back on the body. We need to add an extra push at the end though. This is under the assumption that the condition code cannot corrupt the body results, which is safe to assume as it's an expression not a statement.