### PR TITLE
Fix ip in naked return

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -68,7 +68,7 @@ func (vm *Type) Run(retResult bool) (value.Type, error) {
 		instr := (*cs)[ip]
 
 		// TODO allow tracing flag
-		fmt.Printf("%8d | %8p | %v\n", ip, ctxp, instr)
+		// fmt.Printf("%8d | %8p | %v\n", ip, ctxp, instr)
 
 		opCode := instr.OpCode()
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -68,7 +68,7 @@ func (vm *Type) Run(retResult bool) (value.Type, error) {
 		instr := (*cs)[ip]
 
 		// TODO allow tracing flag
-		// fmt.Printf("%8d | %8p | %v\n", ip, ctxp, instr)
+		fmt.Printf("%8d | %8p | %v\n", ip, ctxp, instr)
 
 		opCode := instr.OpCode()
 
@@ -390,7 +390,7 @@ func (vm *Type) Run(retResult bool) (value.Type, error) {
 			if nip == nil {
 				m.ResetSP()
 				m.Push(val)
-				ip = len(*cs)
+				ip = len(*cs) - 1
 				break
 			}
 			lip, ok := nip.ToInt()


### PR DESCRIPTION
In a repl the following caused a panic:

     return i
     return i

This was because the naked return didn't set the ip correctly for the next run, not taking into account that the ip is incremented in the run loop.