### PR TITLE
fixed panic when comparing list nodes

### DIFF
--- a/cmd/calc/calc_test.go
+++ b/cmd/calc/calc_test.go
@@ -292,6 +292,9 @@ var testData = [...]TestDatum{
 	},
 	// when one of the iterators never yield
 	{"regression/parallel for value", "for i, j <- elems(\"ab\"), fromto(1, 1) 10", nil, value.Nil, nil},
+	{"regression/[1]+[2]+[3]",
+		"[1]+[2]+[3]",
+		nil, value.NewArray([]value.Type{value.NewInt(1), value.NewInt(2), value.NewInt(3)}), nil},
 
 	{"qsort",
 		`{

--- a/types/node/bytecoder.go
+++ b/types/node/bytecoder.go
@@ -298,7 +298,12 @@ func (b BinOp) byteCode(srcsel int, fl flags.Pass, cr compResult) bytecode.Type 
 		tempified = true
 	}
 
-	if tempified && b.Left == b.Right {
+	_, nonComparable := b.Left.(List)
+	if !nonComparable {
+		_, nonComparable = b.Right.(List)
+	}
+
+	if tempified && !nonComparable && b.Left == b.Right {
 		// some common sub-expression elimination
 		instr := bytecode.New(bytecode.PUSHTMP)
 		*cr.CS = append(*cr.CS, instr)


### PR DESCRIPTION
The following code caused panic

     [1]+[2]+[3]

because binop tried to compare left and right if they match, but that cannot be done for list nodes