### PR TITLE
Small optimisation for discarding while

### DIFF
--- a/types/node/bytecoder.go
+++ b/types/node/bytecoder.go
@@ -580,12 +580,16 @@ func discardingWhile(w While, srcsel int, fl flags.Pass, cr compResult) bytecode
 	condAddr := len(*cr.CS)
 	jmpfAddr := condition(w.Condition, true, 0, fl.Data().Pass(), cr)
 
+	bodyAddr := len(*cr.CS)
 	body := w.Body.byteCode(0, fl.Data().Pass(flags.WithDiscard(true)), cr)
 
 	if body.Src0() == bytecode.AddrStck {
 		instr := bytecode.New(bytecode.POP)
 		*cr.CS = append(*cr.CS, instr)
 	}
+
+	jumpBackAddr := condition(w.Condition, false, 0, fl.Data().Pass(), cr)
+	(*cr.CS)[jumpBackAddr] |= bytecode.EncodeSrc(1, bytecode.AddrImm, bodyAddr-jumpBackAddr)
 
 	instr := bytecode.New(bytecode.JMP) | bytecode.EncodeSrc(0, bytecode.AddrImm, condAddr-len(*cr.CS))
 	*cr.CS = append(*cr.CS, instr)

--- a/types/node/bytecoder.go
+++ b/types/node/bytecoder.go
@@ -577,7 +577,6 @@ func (w While) byteCode(srcsel int, fl flags.Pass, cr compResult) bytecode.Type 
 }
 
 func discardingWhile(w While, srcsel int, fl flags.Pass, cr compResult) bytecode.Type {
-	condAddr := len(*cr.CS)
 	jmpfAddr := condition(w.Condition, true, 0, fl.Data().Pass(), cr)
 
 	bodyAddr := len(*cr.CS)
@@ -590,9 +589,6 @@ func discardingWhile(w While, srcsel int, fl flags.Pass, cr compResult) bytecode
 
 	jumpBackAddr := condition(w.Condition, false, 0, fl.Data().Pass(), cr)
 	(*cr.CS)[jumpBackAddr] |= bytecode.EncodeSrc(1, bytecode.AddrImm, bodyAddr-jumpBackAddr)
-
-	instr := bytecode.New(bytecode.JMP) | bytecode.EncodeSrc(0, bytecode.AddrImm, condAddr-len(*cr.CS))
-	*cr.CS = append(*cr.CS, instr)
 
 	// patch the JMPF
 	(*cr.CS)[jmpfAddr] |= bytecode.EncodeSrc(1, bytecode.AddrImm, len(*cr.CS)-jmpfAddr)


### PR DESCRIPTION
Pushing while was already translated to a postcondition loop, but discarding while was missed. Eliminates an extra JMP from the loop body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved handling of while loops in bytecode generation, enhancing the efficiency and correctness of jump addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->