### PR TITLE
small optimisation in yield

### DIFF
--- a/types/node/bytecoder.go
+++ b/types/node/bytecoder.go
@@ -205,8 +205,15 @@ func (r Return) byteCode(srcsel int, fl flags.Pass, cr compResult) bytecode.Type
 }
 
 func (y Yield) byteCode(srcsel int, fl flags.Pass, cr compResult) bytecode.Type {
-	instr := y.Target.byteCode(0, fl.Data().Pass(), cr)
-	instr |= bytecode.New(bytecode.YIELD)
+	target := y.Target.byteCode(0, fl.Data().Pass(), cr)
+	instr := bytecode.New(bytecode.YIELD) | target
+	*cr.CS = append(*cr.CS, instr)
+
+	if fl.Data().Discard {
+		return bytecode.EncodeSrc(srcsel, bytecode.AddrInv, 0)
+	}
+
+	instr = bytecode.New(bytecode.PUSHTMP)
 	*cr.CS = append(*cr.CS, instr)
 
 	return bytecode.EncodeSrc(srcsel, bytecode.AddrStck, 0)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -471,11 +471,7 @@ func (vm *Type) Run(retResult bool) (value.Type, error) {
 			ip = ctxp.ip
 
 		case bytecode.YIELD:
-			val := vm.fetch(instr.Src0(), instr.Src0Addr(), m, ds)
-
-			// yield needs to push in the slave context because a subsequent pop, we
-			// should optimise this away
-			m.Push(val)
+			tmp = vm.fetch(instr.Src0(), instr.Src0Addr(), m, ds)
 
 			// otherwise naked yield, in the master context
 			if ctxp.parent != nil {
@@ -487,7 +483,7 @@ func (vm *Type) Run(retResult bool) (value.Type, error) {
 				m = ctxp.m
 				ip = ctxp.ip
 
-				m.Push(val)
+				m.Push(tmp)
 			}
 
 		case bytecode.READ:


### PR DESCRIPTION
yield most of the time doesn't need to push in the context it's invoked at. We often compiled in an extra push. However sometimes it does need to leave the yielded value on the stack. We can use the tmp register to save the value, and needed we can do a PUSHTMP. This is safe because if yield was invoked from a for loop the for will throw away the iteration result anyway. And if yield wasn't called from a for loop, there is no context switch that would corrupt tmp.

small speed improvement on euler_35_new